### PR TITLE
Add an option useful when animating

### DIFF
--- a/jquery-hide-show.js
+++ b/jquery-hide-show.js
@@ -36,7 +36,11 @@ $(document).ready(function(){
           $this.html( '<button class="' + $hideshow_prefix_classes + 'expandmore__button js-expandmore-button">' + $expandmore_text + '</button>' );
           $button = $this.children('.js-expandmore-button');
           
-          $to_expand.addClass( $hideshow_prefix_classes + 'expandmore__to_expand' );
+          $to_expand.addClass( $hideshow_prefix_classes + 'expandmore__to_expand' ).stop().delay( 300 ).queue( function() {
+            if ($(this).hasClass('js-first_load')) {
+              $(this).removeClass('js-first_load');
+            }
+          });
           
           $button.attr('id', 'label_expand_' + index_lisible);
           $button.attr(attr_control, 'expand_' + index_lisible);


### PR DESCRIPTION
When animating the hide/show system, if hidden content is very large we'll see it disappear on first load (due to `max-height` transitionning).

This code needs a `.js-first_load` class on `.js-to_expand` in `HTML`. Applying 
```
.js-first_load {
  display: none;
}
``` 
will prevent the block to be drawn and then disappear (it won't be displayed at all). When the script is initializing, we already add a class on the `.js-to_expand`, so I just hooked on and remove the new `.js-first_load` class after `300 ms`(which is my `transition-duration`value). This value will ensure that no transition will be seen when loading the page.

What's your opinion on this?

It does work for me but I may have missed a point.