### PR TITLE
Option to expand one item at a time

### DIFF
--- a/jquery-accessible-hide-show-aria.js
+++ b/jquery-accessible-hide-show-aria.js
@@ -15,7 +15,8 @@ jQuery(document).ready(function($) {
         $expandmore = $('.js-expandmore'),
         $body = $('body'),
         delay = 1500,
-        hash = window.location.hash.replace("#", "");
+        hash = window.location.hash.replace("#", ""),
+        multiexpandable = false;
 
 
     if ($expandmore.length) { // if there are at least one :)
@@ -63,6 +64,13 @@ jQuery(document).ready(function($) {
             $destination = $('#' + $this.attr(attr_control));
 
         if ($this.attr(attr_expanded) === 'false') {
+
+            if (multiexpandable == false) {
+                $('button').removeClass('is-opened').attr(attr_expanded, 'false');
+                $('div').attr(attr_hidden, 'true');
+                console.log('all collapsed');
+            }
+            
             $this.addClass('is-opened').attr(attr_expanded, 'true');
             $destination.removeAttr(attr_hidden);
         } else {

--- a/jquery-accessible-hide-show-aria.js
+++ b/jquery-accessible-hide-show-aria.js
@@ -69,6 +69,9 @@ jQuery(document).ready(function($) {
                 $('button').removeClass('is-opened').attr(attr_expanded, 'false');
                 $('div').attr(attr_hidden, 'true');
                 console.log('all collapsed');
+            if (multiexpandable === false) {
+                $('.js-expandmore-button').removeClass('is-opened').attr(attr_expanded, 'false');
+                $('.js-to_expand').attr(attr_hidden, 'true');
             }
             
             $this.addClass('is-opened').attr(attr_expanded, 'true');

--- a/jquery-accessible-hide-show-aria.js
+++ b/jquery-accessible-hide-show-aria.js
@@ -65,10 +65,6 @@ jQuery(document).ready(function($) {
 
         if ($this.attr(attr_expanded) === 'false') {
 
-            if (multiexpandable == false) {
-                $('button').removeClass('is-opened').attr(attr_expanded, 'false');
-                $('div').attr(attr_hidden, 'true');
-                console.log('all collapsed');
             if (multiexpandable === false) {
                 $('.js-expandmore-button').removeClass('is-opened').attr(attr_expanded, 'false');
                 $('.js-to_expand').attr(attr_hidden, 'true');


### PR DESCRIPTION
I've met this case at work so I submit this change if you like.

Use case:
- Several expandable contents
- Only one has to be opened at a time
- Those contents are not directly related in the source code (or I would have use accordion system instead)