### PR TITLE
Accessibility : add a span in button.expandmore__button

### DIFF
--- a/jquery-accessible-hide-show-aria.js
+++ b/jquery-accessible-hide-show-aria.js
@@ -30,7 +30,7 @@ jQuery(document).ready(function($) {
                 $to_expand = $this.next(".js-to_expand"),
                 $expandmore_text = $this.html();
 
-            $this.html('<button type="button" class="' + $hideshow_prefix_classes + 'expandmore__button js-expandmore-button">' + $expandmore_text + '</button>');
+            $this.html('<button type="button" class="' + $hideshow_prefix_classes + 'expandmore__button js-expandmore-button"><span class="expand-symbol" aria-hidden="true"></span>' + $expandmore_text + '</button>');
             var $button = $this.children('.js-expandmore-button');
 
             $to_expand.addClass($hideshow_prefix_classes + 'expandmore__to_expand').stop().delay(delay).queue(function() {


### PR DESCRIPTION
**Avoid ::before or ::after content directly added to the button to be read by some AT**

Actuellement on peut poser un symbole ouvert/fermé via css comme ça : 

```
.expandmore__button[aria-expanded=false]:before,
.expandmore__button[data-expanded=false]:before{
  content : '+ ';
  speak: none;
}
.expandmore__button[aria-expanded=true]:before,
.expandmore__button[data-expanded=true]:before{
  content : '- ';
  speak: none;
}
```

Le problème c'est que malheureusement certaines aides techniques énoncent ce contenu, même avec la propriété css speak: none.

Cette pull request propose donc d'ajouter un span dans le bouton, avec l'attribut aria-hidden="true" qu'on pourra utiliser pour poser les symboles en ::before ou ::after de cet élément.